### PR TITLE
Add a configuration for specifying which port to use for mail

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -70,6 +70,7 @@ swiftmailer:
   transport: "%mailer_transport%"
   host:      "%mailer_host%"
   username:  "%mailer_user%"
+  port:      "%mailer_port%"
   password:  "%mailer_password%"
   spool:     { type: memory }
 

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -9,6 +9,7 @@ parameters:
 
     mailer_transport:  sendmail
     mailer_host:       127.0.0.1
+    mailer_port:       25
     mailer_user:       ~
     mailer_password:   ~
     mailer_from_email: webmaster@ik3.os2display.vm


### PR DESCRIPTION
We needed to customize the smtp-port used to send mail for local development environments. The configuration is available in swiftmailer so it was just a matter of introducing a new entry in parameters.yml.dist and pass it on to swiftmailer.

Be aware that new upon deploying this change composer will prompt for a value for the port to introduce into th parameters.yml in use in the particular environment. This can be avoided by introducing the parameter manually before doing the `composer install`