### PR TITLE
Introduce a configuration that points a public endpoint for the search-host

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -41,6 +41,7 @@ twig:
         sharing_host: '%sharing_host%'
         sharing_enabled: '%sharing_enabled%'
         search_host: '%search_host%'
+        search_host_public: '%search_host_public%'
         search_index: '%search_index%'
         site_title: '%site_title%'
         version: '%version%'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -35,6 +35,7 @@ parameters:
     sharing_enabled: true
 
     search_host: http://127.0.0.1:3010
+    search_host_public: ~
     search_path: /api
     search_apikey: 1234567890
     search_index: e7df7cd2ca07f4f1ab415d457a6e1c13


### PR DESCRIPTION
The search-host is accessed both by the admin-backend, and directly by the
administrative-users browser. For situations where the public url for
the search-host is not accessible to the backend (eg. due to firewalls) we need
two seperate configurations for the public url (for the users browser) and the
internal url (for backend interaction).

**Notice**: even tough additions to parameters.yml.dist should lead to the parameters.yml being updated automatically at next deploy, this does not seem to happen.
In other words, prior to deploying this change to an existing environment you have to
introduce the parameter manually into parameters.yml. (I might also just be wrong, but
this has been my experience so far).