### PR TITLE
Minor language/syntax/link fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,36 @@
 # os2display administrator interface
 
-For general information about installation see the https://github.com/os2display/docs/blob/development/Installation%20guide.md in the docs repository.
+For general information about installation see the [installation guide](https://github.com/os2display/docs/blob/master/installation/Installation%20guide.md) in the docs repository.
 
-# Information
-When working with os2display together with the vagrant provided, you have to visit screen.os2display.vm, search.os2display.vm, middleware.os2display.vm, admin.os2display.vm and accept the self-sign certificates. If you don't open a tab for each in Chrome, if not it will not work.
+## Information
+When working with os2display together with the vagrant provided, you have to visit screen.os2display.vm, search.os2display.vm, middleware.os2display.vm, admin.os2display.vm and accept the self-sign certificates. If you don't open a tab for each in Chrome, it will not work.
 
-# Helpful commands
+## Helpful commands
 We have defined a couple of commands for os2display.
 
-To push content
-<pre>
+To push content:
+```
 php app/console ik:push
-</pre>
+```
 
-To reindex search
-<pre>
+To reindex search:
+```
 php app/console ik:reindex
-</pre>
-This does not include delete of records that are removed from symfony but not search.
+```
+This does not include deletion of records that are removed from symfony but not search.
 
-To clear cache
-<pre>
+To clear cache:
+```
 php app/console cache:clear
-</pre>
+```
 
-To brute force clear cache
-<pre>
+To brute force clear cache:
+```
 rm -rf app/cache/*
-</pre>
+```
 
 
-# API tests
+## API tests
 
 Clear out the acceptance test cache and set up the database:
 


### PR DESCRIPTION
Remove a double negation and some small language/punctuation polish. Changed the several H1's into one H1 and the rest H2. Changed the mixture of html and md markup to a consistent formatting. Corrected broken link to the installation guide and made it a nice link instead of bare URL.